### PR TITLE
Creating data for CL6 (32/64) CL7 (64) CentOS 6 (32/64) CentOS 7 (64)…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ PACKER = /usr/local/bin/packer
 
 all: centos-6-i386.opennebula centos-6-x86_64.opennebula centos-7-x86_64.opennebula \
 	cloudlinux-7-x86_64.opennebula
+test-system: cloudlinux-6-i686.ts cloudlinux-6-x86_64.ts cloudlinux-7-x86_64.ts \
+	centos-6-i686.ts centos-6-x86_64.ts centos-7-x86_64.ts
 
 centos-6-i386.opennebula:
 	$(PACKER) build -only centos-6-i386.opennebula centos-6-i386.opennebula.json
@@ -14,6 +16,24 @@ centos-7-x86_64.opennebula:
 
 cloudlinux-7-x86_64.opennebula:
 	$(PACKER) build -only cloudlinux-7-x86_64.opennebula cloudlinux-7-x86_64.opennebula.json
+
+cloudlinux-6-i686.ts:
+	$(PACKER) build -only cloudlinux-6-i686.ts cloudlinux-6-i686.TS.json
+
+cloudlinux-6-x86_64.ts:
+	$(PACKER) build -only cloudlinux-6-x86_64.ts cloudlinux-6-x86_64.TS.json
+
+cloudlinux-7-x86_64.ts:
+	$(PACKER) build -only cloudlinux-7-x86_64.ts cloudlinux-7-x86_64.TS.json
+
+centos-6-i686.ts:
+	$(PACKER) build -only centos-6-i686.ts centos-6-i686.TS.json
+
+centos-6-x86_64.ts:
+	$(PACKER) build -only centos-6-x86_64.ts centos-6-x86_64.TS.json
+
+centos-7-x86_64.ts:
+	$(PACKER) build -only centos-7-x86_64.ts centos-7-x86_64.TS.json
 
 clean:
 	rm -fr builds

--- a/centos-6-i686.TS.json
+++ b/centos-6-i686.TS.json
@@ -1,0 +1,61 @@
+{
+  "description": "CentOS 6.7 i386 image template for OpenNebula for Test System",
+  "variables": {
+    "iso_checksum_type": "sha1",
+    "ssh_username": "root",
+    "ssh_password": "vagrant"
+  },
+  "provisioners": [
+    {
+      "type": "shell",
+      "scripts": [
+        "provisioners/epel.sh",
+        "provisioners/opennebula.sh",
+        "provisioners/cleanup_vm.sh"
+      ]
+    }
+  ],
+  "builders": [
+    {
+      "name": "centos-6-i686.ts",
+      "type": "qemu",
+      "iso_urls": [
+        "http://ftp.rrzn.uni-hannover.de/centos/6.7/isos/i386/CentOS-6.7-i386-netinstall.iso",
+        "http://ftp.agh.edu.pl/centos/6/isos/i386/CentOS-6.7-i386-netinstall.iso",
+        "http://repo.fedora.md/centos/6/isos/i386/CentOS-6.7-i386-netinstall.iso"
+      ],
+      "iso_checksum": "710c24a02b8ff8fd9783defbc13a43c6b6877027",
+      "iso_checksum_type": "sha1",
+      "output_directory": "builds/centos-6-i686.ts",
+      "shutdown_command": "shutdown -P now",
+      "disk_size": 1200,
+      "format": "raw",
+      "headless": true,
+      "accelerator": "kvm",
+      "http_directory": "http",
+      "ssh_username": "root",
+      "ssh_password": "vagrant",
+      "ssh_wait_timeout": "3600s",
+      "vm_name": "centos-6-i386.ts.{{isotime \"20060102\"}}",
+      "net_device": "virtio-net",
+      "disk_interface": "virtio",
+      "boot_wait": "5s",
+      "qemuargs": [
+        ["-m", "1024"]
+      ],
+      "boot_command": [
+        "<tab>",
+        " append edd=off ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-6-i386.opennebula.ks.cfg<enter>",
+        "<enter>"
+      ]
+    }
+  ],
+  "post-processors": [
+    {
+      "type": "compress",
+      "output": "builds/centos-6-i686.ts/centos-6-i686.ts.{{isotime \"20060102\"}}.gz",
+      "keep_input_artifact": true,
+      "compression_level": 9
+     }
+  ]
+}

--- a/centos-6-x86_64.TS.json
+++ b/centos-6-x86_64.TS.json
@@ -1,0 +1,61 @@
+{
+  "description": "CentOS 6.7 x86_64 image template for OpenNebula for Test System",
+  "variables": {
+    "iso_checksum_type": "sha1",
+    "ssh_username": "root",
+    "ssh_password": "vagrant"
+  },
+  "provisioners": [
+    {
+      "type": "shell",
+      "scripts": [
+        "provisioners/epel.sh",
+        "provisioners/opennebula.sh",
+        "provisioners/cleanup_vm.sh"
+      ]
+    }
+  ],
+  "builders": [
+    {
+      "name": "centos-6-x86_64.ts",
+      "type": "qemu",
+      "iso_urls": [
+        "http://ftp.rrzn.uni-hannover.de/centos/6/isos/x86_64/CentOS-6.7-x86_64-netinstall.iso",
+        "http://ftp.agh.edu.pl/centos/6/isos/x86_64/CentOS-6.7-x86_64-netinstall.iso",
+        "http://repo.fedora.md/centos/6/isos/x86_64/CentOS-6.7-x86_64-netinstall.iso"
+      ],
+      "iso_checksum": "c3678c6b72cbf2ed9b4e8a1ddb190fd262db8b7f",
+      "iso_checksum_type": "sha1",
+      "output_directory": "builds/centos-6-x86_64.ts",
+      "shutdown_command": "shutdown -P now",
+      "disk_size": 1200,
+      "format": "raw",
+      "headless": true,
+      "accelerator": "kvm",
+      "http_directory": "http",
+      "ssh_username": "root",
+      "ssh_password": "vagrant",
+      "ssh_wait_timeout": "3600s",
+      "vm_name": "centos-6-x86_64.ts.{{isotime \"20060102\"}}",
+      "net_device": "virtio-net",
+      "disk_interface": "virtio",
+      "boot_wait": "5s",
+      "qemuargs": [
+        ["-m", "1024"]
+      ],
+      "boot_command": [
+        "<tab>",
+        " append edd=off ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-6-x86_64.opennebula.ks.cfg<enter>",
+        "<enter>"
+      ]
+    }
+  ],
+  "post-processors": [
+    {
+      "type": "compress",
+      "output": "builds/centos-6-x86_64.ts/centos-6-x86_64.ts.{{isotime \"20060102\"}}.gz",
+      "keep_input_artifact": true,
+      "compression_level": 9
+     }
+  ]
+}

--- a/centos-7-x86_64.TS.json
+++ b/centos-7-x86_64.TS.json
@@ -1,0 +1,56 @@
+{
+  "description": "CentOS 7.2 x86_64 image template for OpenNebula for Test System",
+  "provisioners": [
+    {
+      "type": "shell",
+      "scripts": [
+        "provisioners/epel.sh",
+        "provisioners/opennebula.sh",
+        "provisioners/cleanup_vm.sh"
+      ]
+    }
+  ],
+  "builders": [
+    {
+      "name": "centos-7-x86_64.ts",
+      "type": "qemu",
+      "iso_urls": [
+        "http://ftp.rrzn.uni-hannover.de/centos/7/isos/x86_64/CentOS-7-x86_64-NetInstall-1511.iso",
+        "http://ftp.agh.edu.pl/centos/7/isos/x86_64/CentOS-7-x86_64-NetInstall-1511.iso",
+        "http://repo.fedora.md/centos/7/isos/x86_64/CentOS-7-x86_64-NetInstall-1511.iso"
+      ],
+      "iso_checksum": "b9e2480ca2f1b17f27c03f2cf31c4920d5cc70bf",
+      "iso_checksum_type": "sha1",
+      "output_directory": "builds/centos-7-x86_64.ts",
+      "shutdown_command": "shutdown -P now",
+      "disk_size": 1200,
+      "format": "raw",
+      "headless": true,
+      "accelerator": "kvm",
+      "http_directory": "http",
+      "ssh_username": "root",
+      "ssh_password": "vagrant",
+      "ssh_wait_timeout": "3600s",
+      "vm_name": "centos-7-x86_64.ts.{{isotime \"20060102\"}}",
+      "net_device": "virtio-net",
+      "disk_interface": "virtio",
+      "boot_wait": "5s",
+      "qemuargs": [
+        ["-m", "1024"]
+      ],
+      "boot_command": [
+        "<tab>",
+        " text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-7-x86_64.opennebula.ks.cfg<enter>",
+        "<enter>"
+      ]
+    }
+  ],
+  "post-processors": [
+    {
+      "type": "compress",
+      "output": "builds/centos-7-x86_64.ts/centos-7-x86_64.ts.{{isotime \"20060102\"}}.gz",
+      "keep_input_artifact": true,
+      "compression_level": 9
+     }
+  ]
+}

--- a/cloudlinux-6-i686.TS.json
+++ b/cloudlinux-6-i686.TS.json
@@ -1,0 +1,58 @@
+{
+  "description": "CloudLinux 6 i686 image template for OpenNebula for Test System",
+  "provisioners": [
+    {
+      "type": "shell",
+      "scripts": [
+        "provisioners/enable_cl_internal_repos.sh",
+        "provisioners/epel.sh",
+        "provisioners/opennebula.sh",
+        "provisioners/restore_cl_default_repos.sh",
+        "provisioners/cleanup_vm.sh"
+      ]
+    }
+  ],
+  "builders": [
+    {
+      "name": "cloudlinux-6-i686.ts",
+      "type": "qemu",
+      "iso_urls": [
+          "http://koji.cloudlinux.com/cloudlinux/6/iso/i386/CloudLinux-6.7-i386-netinstall.iso",
+          "http://repo.cloudlinux.com/cloudlinux/6/iso/i386/CloudLinux-6.7-i386-netinstall.iso"
+      ],
+      "iso_checksum": "edf2f9abfc96f26e7d2a703c0d4e1cf0c40a1452ff5f3ef365242ad9290da3d1",
+      "iso_checksum_type": "sha256",
+      "output_directory": "builds/cloudlinux-6-i686.ts",
+      "shutdown_command": "shutdown -P now",
+      "disk_size": 1350,
+      "format": "raw",
+      "headless": true,
+      "accelerator": "kvm",
+      "http_directory": "http",
+      "ssh_username": "root",
+      "ssh_password": "vagrant",
+      "ssh_wait_timeout": "3600s",
+      "vm_name": "cloudlinux-6-i686.ts.{{isotime \"20060102\"}}",
+      "net_device": "virtio-net",
+      "disk_interface": "virtio",
+      "boot_wait": "5s",
+      "qemuargs": [
+        ["-m", "1024"],
+        ["-smp", "2"]
+      ],
+      "boot_command": [
+        "<tab>",
+        " text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/cloudlinux-6-i686.opennebula.ks.cfg<enter>",
+        "<enter>"
+      ]
+    }
+  ],
+  "post-processors": [
+    {
+      "type": "compress",
+      "output": "builds/cloudlinux-6-i686.ts/cloudlinux-6-i686.ts.{{isotime \"20060102\"}}.gz",
+      "keep_input_artifact": true,
+      "compression_level": 9
+     }
+  ]
+}

--- a/cloudlinux-6-x86_64.TS.json
+++ b/cloudlinux-6-x86_64.TS.json
@@ -1,0 +1,58 @@
+{
+  "description": "CloudLinux 6 x86_64 image template for OpenNebula for Test System",
+  "provisioners": [
+    {
+      "type": "shell",
+      "scripts": [
+        "provisioners/enable_cl_internal_repos.sh",
+        "provisioners/epel.sh",
+        "provisioners/opennebula.sh",
+        "provisioners/restore_cl_default_repos.sh",
+        "provisioners/cleanup_vm.sh"
+      ]
+    }
+  ],
+  "builders": [
+    {
+      "name": "cloudlinux-6-x86_64.ts",
+      "type": "qemu",
+      "iso_urls": [
+          "http://koji.cloudlinux.com/cloudlinux/6/iso/x86_64/CloudLinux-6.7-x86_64-netinstall.iso",
+          "http://repo.cloudlinux.com/cloudlinux/6/iso/x86_64/CloudLinux-6.7-x86_64-netinstall.iso"
+      ],
+      "iso_checksum": "7e02358933a242634dc394c43109e8da03e57cdec66338aa1ba6d53d55a80d0c",
+      "iso_checksum_type": "sha256",
+      "output_directory": "builds/cloudlinux-6-x86_64.ts",
+      "shutdown_command": "shutdown -P now",
+      "disk_size": 1350,
+      "format": "raw",
+      "headless": true,
+      "accelerator": "kvm",
+      "http_directory": "http",
+      "ssh_username": "root",
+      "ssh_password": "vagrant",
+      "ssh_wait_timeout": "3600s",
+      "vm_name": "cloudlinux-6-x86_64.ts.{{isotime \"20060102\"}}",
+      "net_device": "virtio-net",
+      "disk_interface": "virtio",
+      "boot_wait": "5s",
+      "qemuargs": [
+        ["-m", "1024"],
+        ["-smp", "2"]
+      ],
+      "boot_command": [
+        "<tab>",
+        " text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/cloudlinux-6-x86_64.opennebula.ks.cfg<enter>",
+        "<enter>"
+      ]
+    }
+  ],
+  "post-processors": [
+    {
+      "type": "compress",
+      "output": "builds/cloudlinux-6-x86_64.ts/cloudlinux-6-x86_64.ts.{{isotime \"20060102\"}}.gz",
+      "keep_input_artifact": true,
+      "compression_level": 9
+     }
+  ]
+}

--- a/cloudlinux-7-x86_64.TS.json
+++ b/cloudlinux-7-x86_64.TS.json
@@ -1,0 +1,58 @@
+{
+  "description": "CloudLinux 7.2 x86_64 image template for OpenNebula for Test System",
+  "provisioners": [
+    {
+      "type": "shell",
+      "scripts": [
+        "provisioners/enable_cl_internal_repos.sh",
+        "provisioners/epel.sh",
+        "provisioners/opennebula.sh",
+        "provisioners/restore_cl_default_repos.sh",
+        "provisioners/cleanup_vm.sh"
+      ]
+    }
+  ],
+  "builders": [
+    {
+      "name": "cloudlinux-7-x86_64.ts",
+      "type": "qemu",
+      "iso_urls": [
+          "http://koji.cloudlinux.com/cloudlinux/7/iso/x86_64/CloudLinux-netinst-x86_64-7.2.iso",
+          "http://repo.cloudlinux.com/cloudlinux/7/iso/x86_64/CloudLinux-netinst-x86_64-7.2.iso"
+      ],
+      "iso_checksum": "0fd12caca00043d33785a7f6daadbec38dde111bd7b51559832f262dcdbb2dd9",
+      "iso_checksum_type": "sha256",
+      "output_directory": "builds/cloudlinux-7-x86_64.ts",
+      "shutdown_command": "shutdown -P now",
+      "disk_size": 1200,
+      "format": "raw",
+      "headless": true,
+      "accelerator": "kvm",
+      "http_directory": "http",
+      "ssh_username": "root",
+      "ssh_password": "vagrant",
+      "ssh_wait_timeout": "3600s",
+      "vm_name": "cloudlinux-7-x86_64.ts.{{isotime \"20060102\"}}",
+      "net_device": "virtio-net",
+      "disk_interface": "virtio",
+      "boot_wait": "5s",
+      "qemuargs": [
+        ["-m", "1024"],
+        ["-smp", "2"]
+      ],
+      "boot_command": [
+        "<tab>",
+        " text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/cloudlinux-7-x86_64.opennebula.ks.cfg<enter>",
+        "<enter>"
+      ]
+    }
+  ],
+  "post-processors": [
+    {
+      "type": "compress",
+      "output": "builds/cloudlinux-7-x86_64.ts/cloudlinux-7-x86_64.ts.{{isotime \"20060102\"}}.gz",
+      "keep_input_artifact": true,
+      "compression_level": 9
+     }
+  ]
+}

--- a/http/cloudlinux-6-i686.opennebula.ks.cfg
+++ b/http/cloudlinux-6-i686.opennebula.ks.cfg
@@ -1,0 +1,65 @@
+install
+url --url http://koji.cloudlinux.com/cloudlinux/6/os/i386/
+repo --name=updates --baseurl=http://koji.cloudlinux.com/cloudlinux/6/updates/i386/
+
+lang en_US.UTF-8
+keyboard us
+timezone America/New_York
+
+network --bootproto=dhcp --ipv6=auto
+firewall --enable --service=ssh
+
+authconfig --enableshadow --passalgo=sha512
+selinux --disabled
+services --enabled="sshd,ntpd,ntpdate"
+
+rootpw vagrant
+
+text
+skipx
+
+clearpart --all --initlabel
+zerombr
+bootloader --location=mbr
+part / --fstype ext4 --size=1100 --grow --asprimary
+
+firstboot --disabled
+reboot
+
+%packages
+@Core
+ntp
+ntpdate
+openssh-clients
+sudo
+# don't install unnecessary software
+-alsa*
+-plymouth*
+-NetworkManager*
+# don't install unnecessary firmware
+-ivtv-firmware
+-iwl100-firmware
+-iwl105-firmware
+-iwl135-firmware
+-iwl1000-firmware
+-iwl2000-firmware
+-iwl2030-firmware
+-iwl3160-firmware
+-iwl3945-firmware
+-iwl4965-firmware
+-iwl5000-firmware
+-iwl5150-firmware
+-iwl6000-firmware
+-iwl6000g2a-firmware
+-iwl6000g2b-firmware
+-iwl6050-firmware
+-iwl7260-firmware
+-iwl7265-firmware
+%end
+
+
+%post
+# disable unnecessary services
+#systemctl disable kdump.service
+
+%end

--- a/http/cloudlinux-6-x86_64.opennebula.ks.cfg
+++ b/http/cloudlinux-6-x86_64.opennebula.ks.cfg
@@ -1,0 +1,65 @@
+install
+url --url http://koji.cloudlinux.com/cloudlinux/6/os/x86_64/
+repo --name=updates --baseurl=http://koji.cloudlinux.com/cloudlinux/6/updates/x86_64/
+
+lang en_US.UTF-8
+keyboard us
+timezone America/New_York
+
+network --bootproto=dhcp --ipv6=auto
+firewall --enable --service=ssh
+
+authconfig --enableshadow --passalgo=sha512
+selinux --disabled
+services --enabled="sshd,ntpd,ntpdate"
+
+rootpw vagrant
+
+text
+skipx
+
+clearpart --all --initlabel
+zerombr
+bootloader --location=mbr
+part / --fstype ext4 --size=1100 --grow --asprimary
+
+firstboot --disabled
+reboot
+
+%packages
+@Core
+ntp
+ntpdate
+openssh-clients
+sudo
+# don't install unnecessary software
+-alsa*
+-plymouth*
+-NetworkManager*
+# don't install unnecessary firmware
+-ivtv-firmware
+-iwl100-firmware
+-iwl105-firmware
+-iwl135-firmware
+-iwl1000-firmware
+-iwl2000-firmware
+-iwl2030-firmware
+-iwl3160-firmware
+-iwl3945-firmware
+-iwl4965-firmware
+-iwl5000-firmware
+-iwl5150-firmware
+-iwl6000-firmware
+-iwl6000g2a-firmware
+-iwl6000g2b-firmware
+-iwl6050-firmware
+-iwl7260-firmware
+-iwl7265-firmware
+%end
+
+
+%post
+# disable unnecessary services
+#systemctl disable kdump.service
+
+%end


### PR DESCRIPTION
Creating data for CL6 (32/64) CL7 (64) CentOS 6 (32/64) CentOS 7 (64) images.

Then was created target test-system and now all images for test-system can be created by command:

make test-system PACKER=<Path-to-Packer>
